### PR TITLE
Fix date formatter encoding and build error on macOS

### DIFF
--- a/Sources/PocketBase/Helpers/Bundle+helper.swift
+++ b/Sources/PocketBase/Helpers/Bundle+helper.swift
@@ -118,6 +118,8 @@ extension Bundle {
       case "i386", "x86_64": return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))"
       default: return identifier
       }
+      #else
+      return identifier
       #endif
     }
     

--- a/Sources/PocketBase/Helpers/DateFormatter+helper.swift
+++ b/Sources/PocketBase/Helpers/DateFormatter+helper.swift
@@ -11,8 +11,9 @@ public extension DateFormatter {
   /// Default date formatting used by PocketBase server.
   static let defaultPocketBase: DateFormatter = {
     let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ"
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSX"
     formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = .init(secondsFromGMT: 0)
     formatter.calendar = Calendar(identifier: .iso8601)
     return formatter
   }()


### PR DESCRIPTION
This allows using the same date formatter in query filters.

Example:
```swift
await pocketbase.collection("table")
  .getFullList(
    filter: "updated > '\(DateFormatter.defaultPocketbase.string(from: date))'"
  )
```

Previously local timezone would be appended to the date, which parses wrong in pocketbase.