### PR TITLE
Fix concurrency crash when subscribing to multiple collections quickly

### DIFF
--- a/Sources/PocketBase/Services/Collection.swift
+++ b/Sources/PocketBase/Services/Collection.swift
@@ -1,6 +1,6 @@
 //
 //  Collection.swift
-//  
+//
 //
 //  Created by zz129869523 on 2022/12/22.
 //
@@ -234,13 +234,15 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
         print(err)
       }
       
-      rt.eventSource?.addEventListener(event, handler: { id, event, data in
-        guard let id else { return }
-        rt.currentId = id
-        
-        guard let data else { return }
-        let dict = Utils.stringToDictionary(text: data)
-        completion(dict)
+      await rt.eventSource?.addEventListener(event, handler: { id, event, data in
+        Task {
+          guard let id else { return }
+          await rt.setCurrentId(id)
+          
+          guard let data else { return }
+          let dict = Utils.stringToDictionary(text: data)
+          completion(dict)
+        }
       })
     }
   }
@@ -251,10 +253,10 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
     let rt = Realtime.shared
     
     let event = recordId == ""
-                ? ""
-                : recordId == "*"
-                  ? self.collection
-                  : self.collection + "/" + recordId
+    ? ""
+    : recordId == "*"
+    ? self.collection
+    : self.collection + "/" + recordId
     
     Task {
       let dict = await rt.unsubscribe(event)
@@ -264,11 +266,11 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
       }
       
       if event == "" {
-        for subscriptions in rt.subscriptions {
-          rt.eventSource?.removeEventListener(subscriptions)
+        for subscriptions in await rt.subscriptions {
+          await rt.eventSource?.removeEventListener(subscriptions)
         }
       } else {
-        rt.eventSource?.removeEventListener(event)
+        await rt.eventSource?.removeEventListener(event)
       }
     }
   }

--- a/Sources/PocketBase/Services/Collection.swift
+++ b/Sources/PocketBase/Services/Collection.swift
@@ -234,16 +234,11 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
         print(err)
       }
       
-      await rt.eventSource?.addEventListener(event, handler: { id, event, data in
-        Task {
-          guard let id else { return }
-          await rt.setCurrentId(id)
-          
-          guard let data else { return }
-          let dict = Utils.stringToDictionary(text: data)
-          completion(dict)
-        }
-      })
+      await rt.addEventListener(event: event) { _, _, data in
+        guard let data else { return }
+        let dict = Utils.stringToDictionary(text: data)
+        completion(dict)
+      }
     }
   }
   
@@ -266,11 +261,9 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
       }
       
       if event == "" {
-        for subscriptions in await rt.subscriptions {
-          await rt.eventSource?.removeEventListener(subscriptions)
-        }
+        await rt.removeAllEventListeners()
       } else {
-        await rt.eventSource?.removeEventListener(event)
+        await rt.removeEventListener(event: event)
       }
     }
   }

--- a/Sources/PocketBase/Services/Collection.swift
+++ b/Sources/PocketBase/Services/Collection.swift
@@ -234,7 +234,7 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
         print(err)
       }
       
-      await rt.addEventListener(event: event) { _, _, data in
+      await rt.addEventListener(event) { _, _, data in
         guard let data else { return }
         let dict = Utils.stringToDictionary(text: data)
         completion(dict)
@@ -248,11 +248,10 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
     let rt = Realtime.shared
     
     let event = recordId == ""
-    ? ""
-    : recordId == "*"
-    ? self.collection
-    : self.collection + "/" + recordId
-    
+                ? ""
+                : recordId == "*"
+                  ? self.collection
+                  : self.collection + "/" + recordId
     Task {
       let dict = await rt.unsubscribe(event)
       let err = try? ErrorResponse(dictionary: dict ?? [:])
@@ -263,7 +262,7 @@ public class Collection<UserModel: AuthModel>: CollectionMethod {
       if event == "" {
         await rt.removeAllEventListeners()
       } else {
-        await rt.removeEventListener(event: event)
+        await rt.removeEventListener(event)
       }
     }
   }

--- a/Sources/PocketBase/Services/Realtime.swift
+++ b/Sources/PocketBase/Services/Realtime.swift
@@ -54,10 +54,6 @@ actor Realtime {
     })
   }
   
-  func setCurrentId(_ currentId: String?) {
-    self.currentId = currentId
-  }
-  
   func subscribe(_ event: String) async -> [String: Any]? {
     setupEventSource()
 
@@ -86,6 +82,25 @@ actor Realtime {
     }
     
     return try? await self.networkService.requset(endpoint: Endpoint<RealtimeRequset>.setSubscriptions(clientId: clientId, subscriptions: self.subscriptions))
+  }
+  
+  func addEventListener(event: String, handler: @escaping (String?, String?, String?) -> Void) {
+    eventSource?.addEventListener(event, handler: { id, event, data in
+      guard let id else { return }
+      self.currentId = id
+      
+      handler(id, event, data)
+    })
+  }
+  
+  func removeEventListener(event: String) {
+    eventSource?.removeEventListener(event)
+  }
+  
+  func removeAllEventListeners() {
+    for subscription in subscriptions {
+      eventSource?.removeEventListener(subscription)
+    }
   }
 }
 

--- a/Sources/PocketBase/Services/Realtime.swift
+++ b/Sources/PocketBase/Services/Realtime.swift
@@ -84,7 +84,7 @@ actor Realtime {
     return try? await self.networkService.requset(endpoint: Endpoint<RealtimeRequset>.setSubscriptions(clientId: clientId, subscriptions: self.subscriptions))
   }
   
-  func addEventListener(event: String, handler: @escaping (String?, String?, String?) -> Void) {
+  func addEventListener(_ event: String, handler: @escaping (String?, String?, String?) -> Void) {
     eventSource?.addEventListener(event, handler: { id, event, data in
       guard let id else { return }
       self.currentId = id
@@ -93,7 +93,7 @@ actor Realtime {
     })
   }
   
-  func removeEventListener(event: String) {
+  func removeEventListener(_ event: String) {
     eventSource?.removeEventListener(event)
   }
   

--- a/Sources/PocketBase/Services/Realtime.swift
+++ b/Sources/PocketBase/Services/Realtime.swift
@@ -8,7 +8,7 @@
 import Foundation
 import EventSource
 
-class Realtime {
+actor Realtime {
   static let shared = Realtime()
   private let networkService: NetworkServiceContract = NetworkService()
   
@@ -52,6 +52,10 @@ class Realtime {
         }
       }
     })
+  }
+  
+  func setCurrentId(_ currentId: String?) {
+    self.currentId = currentId
   }
   
   func subscribe(_ event: String) async -> [String: Any]? {


### PR DESCRIPTION
The crash could happen when concurrently calling `Realtime.eventSource.addEventListener`.